### PR TITLE
add explicit hint to not forget to uncomment the appId on self managed accounts

### DIFF
--- a/docs/src/dropdown.md
+++ b/docs/src/dropdown.md
@@ -35,6 +35,9 @@ config.
 </script>
 ```
 
+If you are using a paid account, **make sure to uncomment the line with the appId and enter the ID!**
+see: https://community.algolia.com/docsearch/run-your-own.html#integration
+
 ## Testing
 
 If you're eager to test DocSearch but don't have any credentials of your own


### PR DESCRIPTION
The necessity of the appId is only explained in the docs linking to this page and the comment in the code may be overseen.

**Summary**

If you just come here from elsewhere directly, missing this is a possible blocker. It can be overseen in the green commented area and can lead to unnecessary support requests, because it fails silently to display the dropdown even if it works with the default test data. See my supporting explanation for others coming from own experience https://stackoverflow.com/a/54960623/1081006

**Result**

 I added a line with cross reference to the content that referenced this. You may change this depending on your documentation policy, because links should be defined in a way that they stay active even after changing the structure of the docs . 

Tipp: This is why we use https://sphinx-doc.org and restructuredText instead of the lesser granular Markdown for writing docs.